### PR TITLE
Better handling of summary file creation

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -117,7 +117,7 @@ process run_manta {
 // 2. Run fermikit
 
 // Try to guess location of fastq file. If we can't find it create it
-// else put that in the fastqs channel.
+// else put that in the fastq channel.
 if (!params.fastq) {
     params.fastq = infer_fastq_from_bam()
 }
@@ -128,7 +128,7 @@ if (!params.fastq) {
             file 'bamfile' from bamfile
 
         output:
-            file 'fastq.fq.gz' into fastqs
+            file 'fastq.fq.gz' into fastq
 
         publishDir 'results'
 
@@ -150,12 +150,12 @@ if (!params.fastq) {
 }
 else {
     // The fastq file already exists, put it in the channel.
-    Channel.fromPath( params.fastq ).set { fastqs }
+    Channel.fromPath( params.fastq ).set { fastq }
 }
 
 process fermikit_calling {
     input:
-        file 'sample.fq.gz' from fastqs
+        file 'sample.fq.gz' from fastq
     output:
         file 'fermikit.vcf.gz'
         file 'fermikit.vcf'

--- a/main.nf
+++ b/main.nf
@@ -50,7 +50,7 @@ if (!bamindex) {
 
         // We only need one core for this part
         clusterOptions = {
-            "-A $params.project -p core"
+            "-A $params.project -p $params.runspecs.core $params.runspecs.extra"
         }
 
         when: params.run_manta == true
@@ -128,7 +128,7 @@ if (!params.fastq) {
 
         // We only need one core for this part
         clusterOptions = {
-            "-A $params.project -p core"
+            "-A $params.project -p $params.runspecs.core $params.runspecs.extra"
         }
 
         when: params.run_fermikit == true

--- a/nextflow.config
+++ b/nextflow.config
@@ -2,7 +2,7 @@ process {
   executor = 'slurm'
   time = '10m'
   clusterOptions = {
-    "-A $params.project -p node"
+    "-A $params.project -p $params.runspecs.node $params.runspecs.extra"
   }
 }
 
@@ -20,4 +20,9 @@ params {
     genome_size = "3g"
     readlen = 150
     ref_fasta = "/sw/data/uppnex/ToolBox/ReferenceAssemblies/hg38make/bundle/2.8/b37/human_g1k_v37.fasta"
+    runspecs {
+        core = 'devcore'
+        node = 'devel'
+        extra = '--qos=short'
+    }
 }


### PR DESCRIPTION
This branch separates out summary file creation into different processes. This makes the case where only one program has been run clearer.

These are the commits (in order of application):
0. Remove `run_intersections` from command line
1. Part of this required a refactoring from the if statements before into using when statements.
2. Better configuration of runspecs for the cluster
3. Split up the post processing into several processes. Bed processing is the same for all and no code-duplication is needed. And then a process for running the intersections (if needed).
