### PR TITLE
Normalize vcf in a separate process

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -5,6 +5,7 @@ params {
     steps = 'manta,vep' // Change on commandline --steps x,y,z
     outdir = "results"
     prefix = ''
+    help = False
 
     // Reference assemblies
     ref_fasta = "/sw/data/uppnex/ToolBox/ReferenceAssemblies/hg38make/bundle/2.8/b37/human_g1k_v37.fasta"


### PR DESCRIPTION
This Pull Request pulls out the `vt` invocation into it's own process, since this is something that should be done before all annotators.