### PR TITLE
Add a "local" profile for running locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ This will run both manta and fermikit, annotate the results with variant
 effect predictor and create summary files for everything in the `results`
 subdirectory.
 
+To run everything locally (only for testing on very small datasets), pass `-profile local` and omit the
+`--project` option.
+
 It is recommended that you set the environment variable `NXF_WORK` to
 something like
 

--- a/main.nf
+++ b/main.nf
@@ -12,7 +12,7 @@ if (params.help) {
     exit 0
 }
 
-if (!params.project) {
+if (!params.project && workflow.profile != 'local') {
     exit 1, 'You need to specify what project to run under, see --help for more information'
 }
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -32,10 +32,19 @@ params {
     }
 }
 
-process {
-    executor = 'slurm'
-    clusterOptions = {
-        "-A $params.project"
+profiles {
+    standard {
+        process {
+            executor = 'slurm'
+            clusterOptions = {
+                "-A $params.project"
+            }
+        }
+    }
+
+    // Pass -profile local to run locally
+    local {
+        process.executor = 'local'
     }
 }
 


### PR DESCRIPTION
Hi, I’m wondering whether I can use the wgs-structvar pipeline in the SweGen project. To test it, I’m running it locally on a small dataset. To simplify this, I’d like to suggest adding a "local" profile, which can be enabled with `-profile local`.