### PR TITLE
Fix: masks/ dir is relative to main script dir

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -182,7 +182,7 @@ process fermikit {
 
 // 3. Create summary files
 
-mask_dir = file("masks")
+mask_dir = file("$baseDir/masks")
 ch_vcfs = ch_manta_vcf.mix( ch_fermi_vcf )
 
 process mask_vcfs {


### PR DESCRIPTION
This change makes it possible to run the workflow from outside of the directory
where `main.nf` is located.