### PR TITLE
Use current versions of samtools and manta

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -13,8 +13,8 @@ params {
 
     // Modules and their versions on the HPC-system
     modules {
-        samtools = 'samtools/0.1.19'
-        manta = 'manta/1.0.0'
+        samtools = 'samtools/1.3'
+        manta = 'manta/1.0.3'
         fermikit = 'fermikit/r178'
         vcftools = "vcftools/0.1.14"
         tabix = "tabix/0.2.6"


### PR DESCRIPTION
- Manta 1.0.0 crashes for me on some input files, whereas 1.0.3 does not
- samtools versions after 0.1.19 have considerably improved error handling

I’m not sure whether there is a policy on version bumps for dependencies, but the Manta update is required in order for the pipeline to be usable for me. The samtools one is just to avoid potential trouble in the future.