### PR TITLE
Slurm book cores

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -64,7 +64,7 @@ process index_bamfile {
     tag "$uuid"
 
     executor choose_executor()
-    time params.runtime.simple
+    time { workflow.profile == 'devel' ? '1h' : params.runtime.simple }
 
     module 'bioinfo-tools'
     module "$params.modules.samtools"
@@ -91,7 +91,7 @@ process manta {
     publishDir "$dir", mode: 'copy', saveAs: { "$params.prefix$it" }
 
     errorStrategy { task.exitStatus == 143 ? 'retry' : 'terminate' }
-    time { params.runtime.caller * 2**(task.attempt-1) }
+    time { workflow.profile == 'devel' ? '1h' : params.runtime.caller * 2 **(task.attempt-1) }
     maxRetries 3
     cpus 16 
 
@@ -129,7 +129,7 @@ process create_fastq {
 
     executor choose_executor()
     
-    time params.runtime.caller
+    time { workflow.profile == 'devel' ? '1h' : params.runtime.caller }
 
     module 'bioinfo-tools'
     module "$params.modules.samtools"
@@ -156,7 +156,7 @@ process fermikit {
     publishDir "$dir", mode: 'copy', saveAs: { "$params.prefix$it" }
 
     errorStrategy { task.exitStatus == 143 ? 'retry' : 'terminate' }
-    time { params.runtime.fermikit * 2**( task.attempt - 1 ) }
+    time { workflow.profile == 'devel' ? '1h' : params.runtime.fermikit * 2**( task.attempt -1 ) }
     maxRetries 3
     cpus 16
 
@@ -195,7 +195,7 @@ process mask_vcfs {
 
     executor choose_executor()
     
-    time params.runtime.simple
+    time { workflow.profile == 'devel' ? '1h' : params.runtime.simple }
 
     module 'bioinfo-tools'
     module "$params.modules.bedtools"
@@ -235,7 +235,7 @@ process intersect_files {
 
     executor choose_executor()
     
-    time params.runtime.simple
+    time { workflow.profile == 'devel' ? '1h' : params.runtime.simple }
 
     module 'bioinfo-tools'
     module "$params.modules.bedtools"
@@ -292,7 +292,7 @@ process normalize_vcf {
 
     executor choose_executor()
     
-    time params.runtime.simple
+    time { workflow.profile == 'devel' ? '1h' : params.runtime.simple }
 
     module 'bioinfo-tools'
     module "$params.modules.vt"
@@ -338,7 +338,7 @@ process variant_effect_predictor {
 
     executor choose_executor()
     queue 'core'
-    time params.runtime.simple
+    time { workflow.profile == 'devel' ? '1h' : params.runtime.simple }
 
     module 'bioinfo-tools'
     module "$params.modules.vep"
@@ -399,7 +399,7 @@ process snpEff {
 
     executor choose_executor()
     
-    time params.runtime.simple
+    time { workflow.profile == 'devel' ? '1h' : params.runtime.simple }
 
     module 'bioinfo-tools'
     module "$params.modules.snpeff"

--- a/main.nf
+++ b/main.nf
@@ -64,7 +64,6 @@ process index_bamfile {
     tag "$uuid"
 
     executor choose_executor()
-    queue 'core'
     time params.runtime.simple
 
     module 'bioinfo-tools'
@@ -94,7 +93,7 @@ process manta {
     errorStrategy { task.exitStatus == 143 ? 'retry' : 'terminate' }
     time { params.runtime.caller * 2**(task.attempt-1) }
     maxRetries 3
-    queue 'node'
+    cpus 16 
 
     module 'bioinfo-tools'
     module "$params.modules.manta"
@@ -129,7 +128,7 @@ process create_fastq {
     tag "$uuid"
 
     executor choose_executor()
-    queue 'core'
+    
     time params.runtime.caller
 
     module 'bioinfo-tools'
@@ -159,7 +158,7 @@ process fermikit {
     errorStrategy { task.exitStatus == 143 ? 'retry' : 'terminate' }
     time { params.runtime.fermikit * 2**( task.attempt - 1 ) }
     maxRetries 3
-    queue 'node'
+    cpus 16
 
     module 'bioinfo-tools'
     module "$params.modules.fermikit"
@@ -195,7 +194,7 @@ process mask_vcfs {
     tag "$uuid $svfile"
 
     executor choose_executor()
-    queue 'core'
+    
     time params.runtime.simple
 
     module 'bioinfo-tools'
@@ -235,7 +234,7 @@ process intersect_files {
     tag "$uuid"
 
     executor choose_executor()
-    queue 'core'
+    
     time params.runtime.simple
 
     module 'bioinfo-tools'
@@ -292,7 +291,7 @@ process normalize_vcf {
     tag "$uuid - $infile"
 
     executor choose_executor()
-    queue 'core'
+    
     time params.runtime.simple
 
     module 'bioinfo-tools'
@@ -399,7 +398,7 @@ process snpEff {
     publishDir "$dir", mode: 'copy', saveAs: { "$params.prefix$it" }
 
     executor choose_executor()
-    queue 'core'
+    
     time params.runtime.simple
 
     module 'bioinfo-tools'

--- a/nextflow.config
+++ b/nextflow.config
@@ -44,6 +44,16 @@ profiles {
             }
         }
     }
+    
+    devel {
+        process {
+            executor = 'slurm'
+            queue 'devcore'
+            clusterOptions = {
+                "-A $params.project"
+            }
+        }
+    }
 
     // Pass -profile local to run locally
     local {

--- a/nextflow.config
+++ b/nextflow.config
@@ -38,6 +38,7 @@ profiles {
     standard {
         process {
             executor = 'slurm'
+            queue = 'core'
             clusterOptions = {
                 "-A $params.project"
             }

--- a/nextflow.config
+++ b/nextflow.config
@@ -48,7 +48,7 @@ profiles {
     devel {
         process {
             executor = 'slurm'
-            queue 'devcore'
+            queue = 'devcore'
             clusterOptions = {
                 "-A $params.project"
             }


### PR DESCRIPTION
This PR:
- Puts `queue core` in the profiles of the config, takes `queue node` out of the `process` blocks
- When a full node should be booked, I put `cpus 16` in the process block
- A profile `devel` will queue in UPPMAX devcore partition
- Each process gets its timelimit set to 1h in case it is running on devcore