### PR TITLE
Vep memory fix

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -339,8 +339,9 @@ process variant_effect_predictor {
 
     queue 'core'
     time params.runtime.simple
+    cpus 4
     clusterOptions = {
-        "-A $params.project -n 4"
+        "-A $params.project"
     }
 
     module 'bioinfo-tools'

--- a/main.nf
+++ b/main.nf
@@ -337,9 +337,11 @@ process variant_effect_predictor {
     tag "$uuid - $infile"
     publishDir "$dir", mode: 'copy', saveAs: { "$params.prefix$it" }
 
-    executor choose_executor()
     queue 'core'
     time params.runtime.simple
+    clusterOptions = {
+        "-A $params.project -n 4"
+    }
 
     module 'bioinfo-tools'
     module "$params.modules.vep"
@@ -383,6 +385,7 @@ process variant_effect_predictor {
         --total_length             \
         --canonical                \
         --ccds                     \
+        --fork \$SLURM_JOB_CPUS_PER_NODE \
         --fields Consequence,Codons,Amino_acids,Gene,SYMBOL,Feature,EXON,PolyPhen,SIFT,Protein_position,BIOTYPE \
         --assembly "\$ASSEMBLY" \
         --offline

--- a/main.nf
+++ b/main.nf
@@ -340,9 +340,6 @@ process variant_effect_predictor {
     queue 'core'
     time params.runtime.simple
     cpus 4
-    clusterOptions = {
-        "-A $params.project"
-    }
 
     module 'bioinfo-tools'
     module "$params.modules.vep"


### PR DESCRIPTION
To make sure the vep process works, we have to run it on 4 cores so we don't reach a memory ceiling. While doing that we might as well run it in parallel as well since we have the resources available.